### PR TITLE
Make constructor of db helper class public.

### DIFF
--- a/helpers/db.php
+++ b/helpers/db.php
@@ -45,7 +45,7 @@
     * @param string $pass
     * @param string $name
     */
-    private function __construct($host, $user, $pass, $name) {
+    public function __construct($host, $user, $pass, $name) {
       parent::__construct($host, $user, $pass, $name);
       if ($this->connect_error) {
         if (defined('headless')) {


### PR DESCRIPTION
This fixes:
```
  PHP Fatal error:  Access level to uDb::__construct() must be public (as in class mysqli) in <www-root>/ulogger-server/helpers/db.php on line 84
```