### PR TITLE
Fix protocol detection when behind HTTPS proxy

### DIFF
--- a/helpers/utils.php
+++ b/helpers/utils.php
@@ -116,6 +116,10 @@
      */
     public static function getBaseUrl() {
       $proto = (!isset($_SERVER["HTTPS"]) || $_SERVER["HTTPS"] == "" || $_SERVER["HTTPS"] == "off") ? "http://" : "https://";
+      // Check if we are behind an https proxy
+      if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+        $proto = 'https://';
+      }
       $host = isset($_SERVER["HTTP_HOST"]) ? $_SERVER["HTTP_HOST"] : "";
       if (realpath($_SERVER["SCRIPT_FILENAME"])) {
         $scriptPath = substr(dirname(realpath($_SERVER["SCRIPT_FILENAME"])), strlen(ROOT_DIR));


### PR DESCRIPTION
Hi !

Thanks for this cool project. I set it up as a docker container running behind an HTTPS nginx proxy.

Since nginx was forwarding HTTP requests, the `uUtils::getBaseUrl()` did not detect the right protocol.

This pull request fixes that.

Regards,