### PR TITLE
add: ssl for docker container

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -1,6 +1,10 @@
+ssl_certificate     /etc/letsencrypt/live/---SERVER_ADDRESS---/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/---SERVER_ADDRESS---/privkey.pem;
+
 server {
-	listen 80;
-	listen [::]:80;
+    server_name  ---SERVER_ADDRESS---;
+	listen 443 ssl;
+	listen [::]:443 ssl;
 	root /var/www/html;
 	index index.php;
 	client_body_buffer_size 1M;

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG DB_ROOT_PASS=secret1
 ARG DB_USER_PASS=secret2
 # supported drivers: mysql, pgsql, sqlite
 ARG DB_DRIVER=mysql
+ARG ULOGGER_SERVER_ADDRESS
 
 ENV ULOGGER_ADMIN_USER admin
 ENV ULOGGER_DB_DRIVER ${DB_DRIVER}
@@ -26,6 +27,7 @@ COPY .docker/init.sh /init.sh
 RUN chmod +x /init.sh
 COPY .docker/nginx.conf /etc/nginx/conf.d/default.conf
 RUN chown nginx.nginx /etc/nginx/conf.d/default.conf
+RUN sed -i "s/---SERVER_ADDRESS---/${ULOGGER_SERVER_ADDRESS}/g" /etc/nginx/conf.d/default.conf
 
 RUN rm -rf /var/www/html
 RUN mkdir -p /var/www/html
@@ -38,7 +40,7 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
     ln -sf /dev/stdout /var/log/php7/error.log && \
     ln -sf /dev/stderr /var/log/php7/error.log
 
-EXPOSE 80
+EXPOSE 443
 
 VOLUME ["/data"]
 


### PR DESCRIPTION
I made some changes so the docker container enables ssl via letscrypt certificates in `/etc/letsencrypt/live/<site>/`. Certificates are easily retrieved using https://certbot.eff.org/docs/install.html#running-with-docker while mounting `/etc/letsencrypt` into the local filesystem. Site address is given via ARG, see `Dockerfile`.

I only tested sqlite so far and I'm not sure how to fix travis -- we would probably need some test certificates/domain...

Certbot command to get certificates:

```
BASE="certificates"
mkdir -p "$BASE"
sudo docker run -it --rm --name certbot \
            -v "$BASE/etc/letsencrypt:/etc/letsencrypt" \
            -v "$BASE/var/lib/letsencrypt:/var/lib/letsencrypt" \
            certbot/certbot --standalone certonly
```

Then run the container with corresponding mounts.