### PR TITLE
Docker: Fix sqlite ownership and clean up dockerfile

### DIFF
--- a/.docker/init.sh
+++ b/.docker/init.sh
@@ -50,6 +50,7 @@ elif [ "$ULOGGER_DB_DRIVER" = "sqlite" ]; then
   sqlite3 -init /var/www/html/scripts/ulogger.sqlite /data/sqlite/ulogger.db .exit
   sqlite3 -line /data/sqlite/ulogger.db "INSERT INTO users (login, password, admin) VALUES ('${ULOGGER_ADMIN_USER}', '\$2y\$10\$7OvZrKgonVZM9lkzrTbiou.CVhO3HjPk5y0W9L68fVwPs/osBRIMq', 1)"
   sed -i "s/^\$dbdsn = .*$/\$dbdsn = \"sqlite:\/data\/sqlite\/ulogger.db\";/" /var/www/html/config.php
+  chown -R nobody:nobody /data/sqlite
 else
   mkdir -p /run/mysqld /data/mysql
   chown mysql:mysql /run/mysqld /data/mysql

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,15 @@ RUN if [ "${DB_DRIVER}" = "mysql" ]; then apk add --no-cache mariadb mariadb-cli
 RUN if [ "${DB_DRIVER}" = "pgsql" ]; then apk add --no-cache postgresql postgresql-client php7-pdo_pgsql; fi
 RUN if [ "${DB_DRIVER}" = "sqlite" ]; then apk add --no-cache sqlite php7-pdo_sqlite; fi
 
+RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/log/nginx/error.log && \
+    ln -sf /dev/stdout /var/log/php7/error.log && \
+    ln -sf /dev/stderr /var/log/php7/error.log
+
+RUN rm -rf /var/www/html
+RUN mkdir -p /var/www/html
+
+
 COPY .docker/run.sh /run.sh
 RUN chmod +x /run.sh
 COPY .docker/init.sh /init.sh
@@ -27,16 +36,9 @@ RUN chmod +x /init.sh
 COPY .docker/nginx.conf /etc/nginx/conf.d/default.conf
 RUN chown nginx.nginx /etc/nginx/conf.d/default.conf
 
-RUN rm -rf /var/www/html
-RUN mkdir -p /var/www/html
 COPY . /var/www/html
 
 RUN /init.sh "${DB_ROOT_PASS}" "${DB_USER_PASS}"
-
-RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
-    ln -sf /dev/stderr /var/log/nginx/error.log && \
-    ln -sf /dev/stdout /var/log/php7/error.log && \
-    ln -sf /dev/stderr /var/log/php7/error.log
 
 EXPOSE 80
 


### PR DESCRIPTION
sqlite wasn't working because the database was read-only -- the init command is run as root, so we need to change ownership afterwards.

Also, I moved some simple dockerfile commands to earlier in the file so that they are reused more often.